### PR TITLE
removed general enquiry option from file uplaod modal

### DIFF
--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -239,7 +239,7 @@
             </div>
             <div class="modal-body">
                 <form action="{{route('admin.uploadFile')}}" method="POST" enctype="multipart/form-data">
-             
+            
                 <div class="form-group">
                     <label class="btn btn-success" for="fileUpload">
                         Select File
@@ -258,7 +258,6 @@
                         <option value="Fighter App">Fighter Application Page</option>
                         <option value="Sponsor Enquiry">Sponsor Enquiry Page</option>
                         <option value="Table Enquiry">Table Enquiry Page</option>
-                        <option value="General Enquiry">General Enquiry Page</option>
                     </select>
                 </div>
 
@@ -284,7 +283,7 @@
                 </div>
                 <div class="modal-body">
                     <form id="fileUpdateForm" action="" data-action="{{route('admin.updateFile', ['docID' => null])}}" method="POST">
-                       
+                    
                     <div class="form-group">
                         <label for="updateDisplaySelect">Where should this file be downloadable from?</label>
                         <select id="updateDisplaySelect" name="location" class="form-control">


### PR DESCRIPTION
this resolves issue #178 

- removed the option for saving a file to the general enquiry form on the file upload modal.
- there was no link to be removed from the form it self