### PR TITLE
Update event.blade.php

### DIFF
--- a/resources/views/event.blade.php
+++ b/resources/views/event.blade.php
@@ -1,7 +1,7 @@
 @extends('layouts.app') 
 @section('content')
 
-<div class="container-fluid" style="background-color: black;">
+<div style="background-color: black;">
 	<section class="upcoming-section">
 		<div class="container">
 			<div class="row pb-5">


### PR DESCRIPTION
Removed the class `container-fluid` from the events page as it created this odd black margin on both the left and right side of the view making the map/sponsors bar and info sections look out of place.