### PR TITLE
Add historical groups + sitemap.xml + active_url fix

### DIFF
--- a/app/Http/Controllers/admin/EventManagementController.php
+++ b/app/Http/Controllers/admin/EventManagementController.php
@@ -74,7 +74,7 @@ class EventManagementController extends Controller
     public function update(Request $request, $eventID){
         $validator = Validator::make(Input::all(), [ 
             'name' => 'required',
-            'tickets' => 'active_url',
+            'tickets' => 'nullable|active_url',
         ],        
         // error messages
         [

--- a/app/Http/Controllers/admin/GroupManagementController.php
+++ b/app/Http/Controllers/admin/GroupManagementController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\admin;
 use Storage;
 use Illuminate\Support\Facades\Log;
 use App\Group;
+use App\Event;
 use App\User;
 use App\Sponsor;
 use App\Contact;
@@ -263,8 +264,10 @@ class GroupManagementController extends Controller
     /**
      * Returns view of all applicants from current event
      */
-    public function getApplicants(){
-        return view('admin.systemGroupManagement')->with('type', 'Applicants')->with('groups', Group::all());
+    public function getApplicants($eventId){
+        
+        return view('admin.systemGroupManagement')->with('type', 'Applicants')->with('groups', Group::all())
+                                                    ->with('event', Event::find($eventId));;
     }
 
     /**
@@ -279,8 +282,9 @@ class GroupManagementController extends Controller
     /**
      * Returns view of all sponsors from current event
      */
-    public function getSponsors(){
-        return view('admin.systemGroupManagement')->with('type', 'Sponsors')->with('groups', Group::all());
+    public function getSponsors($eventId){
+        return view('admin.systemGroupManagement')->with('type', 'Sponsors')->with('groups', Group::all())
+                                                    ->with('event', Event::find($eventId));;
     }
 
     /**
@@ -295,15 +299,17 @@ class GroupManagementController extends Controller
     /**
      * Returns view of red team for current event
      */
-    public function getRed(){
-        return view('admin.systemGroupManagement')->with('type', 'Red Contenders')->with('groups', Group::all());
+    public function getRed($eventId){
+        return view('admin.systemGroupManagement')->with('type', 'Red Contenders')->with('groups', Group::all())
+                                                    ->with('event', Event::find($eventId));
     }
 
     /**
      * Returns view of blue team for current event
      */
-    public function getBlue(){
-        return view('admin.systemGroupManagement')->with('type', 'Blue Contenders')->with('groups', Group::all());
+    public function getBlue($eventId){
+        return view('admin.systemGroupManagement')->with('type', 'Blue Contenders')->with('groups', Group::all())
+                                                    ->with('event', Event::find($eventId));;
     }
 
     /**

--- a/app/Http/Controllers/admin/SponsorManagementController.php
+++ b/app/Http/Controllers/admin/SponsorManagementController.php
@@ -31,7 +31,7 @@ class SponsorManagementController extends Controller
             'companyName' => 'required',
             'phone' => 'required',
             'email' => 'email|required',
-            'url' => 'active_url',
+            'url' => 'nullable|active_url',
             // 'logo' => 'mimes:png'
         ]);
 
@@ -64,7 +64,7 @@ class SponsorManagementController extends Controller
             'companyName' => 'required',
             'phone' => 'required',
             'email' => 'email|required',
-            'url' => 'active_url',
+            'url' => 'nullable|active_url',
             // 'logo' => 'mimes:png'
         ]);
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+
+<url>
+  <loc>https://fightforkidz.co.nz/</loc>
+  <lastmod>2019-03-09T02:37:01+00:00</lastmod>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://fightforkidz.co.nz/event/Fight-for-Kidz-2019</loc>
+  <lastmod>2019-03-09T02:37:01+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://fightforkidz.co.nz/event/Fight-for-Kidz-2018</loc>
+  <lastmod>2019-03-09T02:37:01+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://fightforkidz.co.nz/fighter-application</loc>
+  <lastmod>2019-03-09T02:37:01+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://fightforkidz.co.nz/contact</loc>
+  <lastmod>2019-03-09T02:37:01+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://fightforkidz.co.nz/login</loc>
+  <lastmod>2019-03-09T02:37:01+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://fightforkidz.co.nz/password/reset</loc>
+  <lastmod>2019-03-09T02:37:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+
+
+</urlset>

--- a/resources/views/admin/eventManagement.blade.php
+++ b/resources/views/admin/eventManagement.blade.php
@@ -185,7 +185,7 @@
                     </div>
                     <div class="form-group">
                         <label for="eventCharity">Supported Charity</label>
-                        <input type="text" name="charity" id="eventCharity" class="form-control" value="{{$event->charity}}" required>
+                        <input type="text" name="charity" id="eventCharity" class="form-control" value="{{$event->charity}}">
                     </div>
                     <div class="form-group">
                         <label for="eventCharitUrly">Charity Url</label>

--- a/resources/views/admin/groupsManagement.blade.php
+++ b/resources/views/admin/groupsManagement.blade.php
@@ -77,26 +77,26 @@
 
                 <div class="row">
 
-                    <div class="col-lg-2 col-md-3 col-sm-6 my-3 px-2">
-                        <a class="btn groups border border-primary" href="{{route('admin.group.applicants')}}">
+                    <div class="col-md-3 col-sm-6 my-3 px-2">
+                        <a class="btn groups border border-primary" href="{{route('admin.group.applicants', ['eventId' => App\Event::current()->id])}}">
                             <h5>Applicants</h5>
                         </a>
                     </div>
 
-                    <div class="col-lg-2 col-md-3 col-sm-6 my-3 px-2">
-                        <a class="btn groups border border-primary" href="{{route('admin.group.red')}}">
+                    <div class="col-md-3 col-sm-6 my-3 px-2">
+                        <a class="btn groups border border-primary" href="{{route('admin.group.red', ['eventId' => App\Event::current()->id])}}">
                             <h5>Red Contenders</h5>
                         </a>
                     </div>
 
-                    <div class="col-lg-2 col-md-3 col-sm-6 my-3 px-2">
-                        <a class="btn groups border border-primary" href="{{route('admin.group.blue')}}">
+                    <div class="col-md-3 col-sm-6 my-3 px-2">
+                        <a class="btn groups border border-primary" href="{{route('admin.group.blue', ['eventId' => App\Event::current()->id])}}">
                             <h5>Blue Contenders</h5>
                         </a>
                     </div>
 
-                    <div class="col-lg-2 col-md-3 col-sm-6 my-3 px-2">
-                        <a class="btn groups border border-primary" href="{{route('admin.group.sponsors')}}">
+                    <div class="col-md-3 col-sm-6 my-3 px-2">
+                        <a class="btn groups border border-primary" href="{{route('admin.group.sponsors', ['eventId' => App\Event::current()->id])}}">
                             <h5>Sponsors</h5>
                         </a>
                     </div>
@@ -110,16 +110,63 @@
 
                 {{-- start of custom groups --}}
                 <div class="row">
-                    @foreach($groups as $group)
-                    <div class="col-lg-3 col-md-4 col-sm-6 my-4 px-2">
-                        <a class="btn groups border border-primary" href="{{ route('admin.group', ['id' => $group->id])}}">
-                            <img class="d-block m-auto group-icon" src="/storage/images/groups/{{($group->custom_icon)?$group->id: 0 }}.png" alt="Group Icon" />
-                            <h5>{{$group->name}}</h5>
-                            <span class="d-block text-center">{{$group->type}}</span>
-                        </a>
-                    </div>
-                    @endforeach
+                    @if(count($groups) > 0)
+                        @foreach($groups as $group)
+                        <div class="col-lg-3 col-md-4 col-sm-6 my-4 px-2">
+                            <a class="btn groups border border-primary" href="{{ route('admin.group', ['id' => $group->id])}}">
+                                <img class="d-block m-auto group-icon" src="/storage/images/groups/{{($group->custom_icon)?$group->id: 0 }}.png" alt="Group Icon" />
+                                <h5>{{$group->name}}</h5>
+                                <span class="d-block text-center">{{$group->type}}</span>
+                            </a>
+                        </div>
+                        @endforeach
+                    @else
+                        <h4 class="text-center my-3 w-100">No custom groups defined</h4>
+                    @endif
                 </div>
+
+                <hr>
+
+                <h3 class="text-center my-5">Previous Event Groups</h3>
+
+                {{-- start of historical groups --}}
+                @foreach(App\Event::all()->sortByDesc('datetime') as $event)
+                    {{-- skip if the event is the current event --}}
+                    @if($event != App\Event::current())
+                        {{-- start of event groups --}}
+                        <h4 class="text-center mt-3">{{$event->name}} Groups</h4>
+
+                        <div class="row">
+
+                            <div class="col-md-3 col-sm-6 my-3 px-2">
+                                <a class="btn groups border border-primary" href="{{route('admin.group.applicants', ['eventId' => $event->id])}}">
+                                    <h5>Applicants</h5>
+                                </a>
+                            </div>
+
+                            <div class="col-md-3 col-sm-6 my-3 px-2">
+                                <a class="btn groups border border-primary" href="{{route('admin.group.red', ['eventId' => $event->id])}}">
+                                    <h5>Red Contenders</h5>
+                                </a>
+                            </div>
+
+                            <div class="col-md-3 col-sm-6 my-3 px-2">
+                                <a class="btn groups border border-primary" href="{{route('admin.group.blue', ['eventId' => $event->id])}}">
+                                    <h5>Blue Contenders</h5>
+                                </a>
+                            </div>
+
+                            <div class="col-md-3 col-sm-6 my-3 px-2">
+                                <a class="btn groups border border-primary" href="{{route('admin.group.sponsors', ['eventId' => $event->id])}}">
+                                    <h5>Sponsors</h5>
+                                </a>
+                            </div>
+                        @endif
+
+                    </div>
+                    {{-- end of event groups --}}
+                @endforeach
+                {{-- end of historical groups --}}
             </div>
             {{-- end of active, start of deleted groups --}}
             <div class="tab-pane {{ (app('request')->input('tab') == 'deleted')? 'active': '' }}" role="tabpanel" id="tab-2">

--- a/resources/views/admin/systemGroupManagement.blade.php
+++ b/resources/views/admin/systemGroupManagement.blade.php
@@ -20,7 +20,7 @@
 
         <div class="card mb-3">
             <div class="card-header bg-primary text-white">
-                <h3 class="mb-0 mr-2 d-inline-block"><i class="fas fa-info-circle"></i> Displaying {{$type}} {!!(in_array($type, ['Applicants', 'Red Contenders', 'Blue Contenders', 'Sponsors'])) ? 'for ' . App\Event::current()->name : ''!!}</h3>
+                <h3 class="mb-0 mr-2 d-inline-block"><i class="fas fa-info-circle"></i> Displaying {{$type}} {!!(in_array($type, ['Applicants', 'Red Contenders', 'Blue Contenders', 'Sponsors'])) ? 'for ' . $event->name : ''!!}</h3>
                 <span>
                     {!!($type == 'All') ? '(excluding <a class="text-white" href="'. route('admin.group.subscribers') .'"><u>subscribers</u></a>)' : ''!!}                    
                 </span>
@@ -98,7 +98,7 @@
 
                 {{-- Applicants loop --}}
                 @if($type == 'All' || $type == 'Applicants' || $type == 'All Applicants')                    
-                    @foreach(($type == 'Applicants' ? App\Applicant::where('event_id', App\Event::current()->id)->get() : App\Applicant::all()) as $member)
+                    @foreach(($type == 'Applicants' ? App\Applicant::where('event_id', $event->id)->get() : App\Applicant::all()) as $member)
                         <tr>
                             <td>
                                 <div class="form-check">
@@ -122,7 +122,7 @@
 
                 {{-- Red team loop --}}
                 @if($type == 'Red Contenders')                    
-                    @foreach(App\Event::current()->getTeam('red') as $member)
+                    @foreach($event->getTeam('red') as $member)
                         <tr>
                             <td>
                                 <div class="form-check">
@@ -141,7 +141,7 @@
 
                 {{-- Blue team loop --}}
                 @if($type == 'Blue Contenders')                    
-                    @foreach(App\Event::current()->getTeam('blue') as $member)
+                    @foreach($event->getTeam('blue') as $member)
                         <tr>
                             <td>
                                 <div class="form-check">
@@ -160,7 +160,7 @@
 
                 {{-- Sponsors loop --}}
                 @if($type == 'All' || $type == "Sponsors" || $type == "All Sponsors")
-                    @foreach(($type == "Sponsors" ? App\Event::current()->sponsors : App\Sponsor::all()) as $member)
+                    @foreach(($type == "Sponsors" ? $event->sponsors : App\Sponsor::all()) as $member)
                         <tr>
                             <td>
                                 <div class="form-check">
@@ -168,7 +168,7 @@
                                         value="checkedValue" data-member-type="sponsor" data-member-id="{{$member['id']}}">
                                 </div>
                             </td>
-                            <td>{{$member['contact_name'] . ' (' . $member['company_name'] . ')'}}</td>
+                            <td>{{$member['contact_name'] ? $member['contact_name'] . ' (' . $member['company_name'] . ')' : $member['company_name']}}</td>
                             <td><a href="mailto:{{$member['email']}}">{{$member['email']}}</a></td>
                             <td>{{$member['contact_phone']}}</td>
                             <td>Sponsor</td>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -42,10 +42,10 @@ Route::get('/group-management/admins', 'admin\GroupManagementController@getAdmin
 Route::get('/group-management/all-applicants', 'admin\GroupManagementController@getAllApplicants')->name('admin.group.allApplicants');
 Route::get('/group-management/all-sponsors', 'admin\GroupManagementController@getAllSponsors')->name('admin.group.allSponsors');
 Route::get('/group-management/others', 'admin\GroupManagementController@getOthers')->name('admin.group.others');
-Route::get('/group-management/red', 'admin\GroupManagementController@getRed')->name('admin.group.red');
-Route::get('/group-management/blue', 'admin\GroupManagementController@getBlue')->name('admin.group.blue');
-Route::get('/group-management/applicants', 'admin\GroupManagementController@getApplicants')->name('admin.group.applicants');
-Route::get('/group-management/sponsors', 'admin\GroupManagementController@getSponsors')->name('admin.group.sponsors');
+Route::get('/group-management/red/{eventId}', 'admin\GroupManagementController@getRed')->name('admin.group.red');
+Route::get('/group-management/blue/{eventId}', 'admin\GroupManagementController@getBlue')->name('admin.group.blue');
+Route::get('/group-management/applicants/{eventId}', 'admin\GroupManagementController@getApplicants')->name('admin.group.applicants');
+Route::get('/group-management/sponsors/{eventId}', 'admin\GroupManagementController@getSponsors')->name('admin.group.sponsors');
 
 //View, Update Group
 Route::get('/group-management/{groupID}', 'admin\GroupManagementController@view')->name('admin.group');


### PR DESCRIPTION
### Description of Changes

- All back-end validation checks involving 'active_url' have been made nullable. They were implicitly non-nullable.

- Remove 'required' tags from the charity name input field on the event edit modal. It is not required in back end checks.

- Added sitemap.xml to public directory

- System group management now gets passed an event object if the user is viewing event specific groups (red/blue team, applicants or sponsors. This is achieved by passing a group id in the URL of those pages.
```
Route::get('/group-management/applicants/{eventId}', 'admin\GroupManagementController@getApplicants')->name('admin.group.applicants');
```