### PR TITLE
Application hotfix - Prevent spaces being entered on email field

### DIFF
--- a/public/js/custom.js
+++ b/public/js/custom.js
@@ -293,3 +293,10 @@ $(document).ready(function () {
     $("#fight-video-modal iframe").attr("src", "");
   });
 });
+
+//removes forward and trailing spaces from any text input
+$(function(){
+  $('input[type="text"]').change(function(){
+      this.value = $.trim(this.value);
+  });
+});

--- a/public/js/custom.js
+++ b/public/js/custom.js
@@ -294,9 +294,16 @@ $(document).ready(function () {
   });
 });
 
-//removes forward and trailing spaces from any text input
-$(function(){
+$(document).ready(function(){
+  //removes forward and trailing spaces from any text input
   $('input[type="text"]').change(function(){
       this.value = $.trim(this.value);
   });
+
+  // prevents user from entering spaces when inputting their email
+  // or any input with the 'noSpaces' class
+  $('.noSpaces').keypress(function(key){
+    if(key.charCode == 32) return false;
+  });
+
 });

--- a/resources/views/fighter-apply.blade.php
+++ b/resources/views/fighter-apply.blade.php
@@ -101,7 +101,7 @@
 											<label class="required" for="email">Email:</label>
 										</div>
 										<div class="col-md-4">
-											<input class="form-control" type="text" name="email" required>
+											<input class="form-control noSpaces" type="text" name="email" required>
 										</div>
 									</div>
 								</div>
@@ -284,7 +284,7 @@
 											<label class="required" for="emergency_email">Email:</label>
 										</div>
 										<div class="col-md-4">
-											<input class="form-control" type="email" name="emergency_email"  required>
+											<input class="form-control noSpaces" type="email" name="emergency_email"  required>
 										</div>
 									</div>
 								</div>


### PR DESCRIPTION
Uses jquery `.change` and `.keypress`  to :

- Trim any leading or trailing white space
- Prevent applicants from entering spaces in email input elements.