### PR TITLE
Shifted closing div tag to fix groups tabs

### DIFF
--- a/resources/views/admin/groupsManagement.blade.php
+++ b/resources/views/admin/groupsManagement.blade.php
@@ -167,7 +167,7 @@
                     {{-- end of event groups --}}
                 @endforeach
                 {{-- end of historical groups --}}
-            </div>
+            
             {{-- end of active, start of deleted groups --}}
             <div class="tab-pane {{ (app('request')->input('tab') == 'deleted')? 'active': '' }}" role="tabpanel" id="tab-2">
                 <div class="row">
@@ -183,6 +183,7 @@
                 </div>
             </div>
             {{-- end of custom groups --}}
+        </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
There are still some stray closing tags floating around, but I am hesitant to muck with them as doing so will likely break other pages. All pages seem to be functioning at the moment.
