### PR TITLE
Hotfix/fix email attachment size

### DIFF
--- a/app/Http/Controllers/admin/MailController.php
+++ b/app/Http/Controllers/admin/MailController.php
@@ -47,7 +47,7 @@ class MailController extends Controller
             'subject' => 'required|string',
             'messageText' => 'required|string',
             'target_groups' => 'required',
-            'messageAttachments.*' => 'max:5000|mimes:doc,docx,bmp,gif,jpg,jpeg,png,pdf,rtf,xls,xlsx,txt',
+            'messageAttachments.*' => 'max:10000|mimes:doc,docx,bmp,gif,jpg,jpeg,png,pdf,rtf,xls,xlsx,txt',
         ]);
         
         $subject = $request->input('subject');

--- a/app/Http/Controllers/admin/MailController.php
+++ b/app/Http/Controllers/admin/MailController.php
@@ -47,7 +47,7 @@ class MailController extends Controller
             'subject' => 'required|string',
             'messageText' => 'required|string',
             'target_groups' => 'required',
-            'messageAttachments.*' => 'max:10000|mimes:doc,docx,bmp,gif,jpg,jpeg,png,pdf,rtf,xls,xlsx,txt',
+            'messageAttachments.*' => 'max:9500|mimes:doc,docx,bmp,gif,jpg,jpeg,png,pdf,rtf,xls,xlsx,txt',
         ]);
         
         $subject = $request->input('subject');

--- a/resources/views/admin/mail.blade.php
+++ b/resources/views/admin/mail.blade.php
@@ -57,7 +57,7 @@
 				</label>
 				<span class="ml-3 gray-card d-none" id="fileName"></span>
                 <span id="clearAttachmentsBtn" class="times-circle-btn d-none"><i class="fas fa-times-circle"></i></span>
-                <p>Attachments must not exceed 10MB total size</p>
+                <p>Attachments must not exceed 9.5MB total size</p>
             </div>
             <div class="form-group w-100">
                 <div class="d-inline-block">

--- a/resources/views/admin/mail.blade.php
+++ b/resources/views/admin/mail.blade.php
@@ -56,7 +56,8 @@
 					<input type="file" multiple="multiple" id="fileUpload" name="messageAttachments[]" class="d-none">
 				</label>
 				<span class="ml-3 gray-card d-none" id="fileName"></span>
-				<span id="clearAttachmentsBtn" class="times-circle-btn d-none"><i class="fas fa-times-circle"></i></span>
+                <span id="clearAttachmentsBtn" class="times-circle-btn d-none"><i class="fas fa-times-circle"></i></span>
+                <p>Attachments must not exceed 10MB total size</p>
             </div>
             <div class="form-group w-100">
                 <div class="d-inline-block">


### PR DESCRIPTION
- Adds a note on the send mail view along the lines of 'Max attachments 10MB'
- Increases server side validation limit for mail attachments (sum of) to 10MB

