### PR TITLE
Sanitize mail preview

### DIFF
--- a/app/Http/Controllers/admin/MailController.php
+++ b/app/Http/Controllers/admin/MailController.php
@@ -38,6 +38,9 @@ class MailController extends Controller
         $empty = []; // have to pass an array
         $messageText = $request->messageText;
 
+        // Purify the input to remove malicious scripts / dangerous html tags
+        $messageText = Purifier::clean($messageText);
+
         return new CustomMail('test@example.com', '<name here>', '<Subject here>', $messageText, $empty);
     }
 


### PR DESCRIPTION
I recently noticed that when previewing mail to be sent, it was not being run through the purifier.

This could lead to discrepancies between the mail preview and the actual mail sent (which _was_ run through the sanitizer), if the admin was to put any prohibited content in the mail.

Fixed by running preview mail through the sanitizer also.

Tested on localhost, no issues detected.

@samuelgrant please review, merge and pull to production when you can.