### PR TITLE
Hotfix/spam prevention

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -14,7 +14,7 @@ class ContactController extends Controller
 {
     public function general(request $request) {
         $validator = Validator::make($request->all(), [
-            //'g-recaptcha-response' => 'required|captcha',
+            'g-recaptcha-response' => 'required|captcha',
             'name' => 'required',
             'email' => 'required|email',
             'phone' => 'required',
@@ -45,7 +45,7 @@ class ContactController extends Controller
     }
     public function sponsor(request $request) {
         $validator = Validator::make($request->all(), [ 
-            //'g-recaptcha-response' => 'required|captcha',
+            'g-recaptcha-response' => 'required|captcha',
             'name' => 'required',
             'companyName' => 'required',
             'email' => 'required|email',
@@ -77,7 +77,7 @@ class ContactController extends Controller
     }
     public function table(request $request) {
         $validator = Validator::make($request->all(), [ 
-            //'g-recaptcha-response' => 'required|captcha',
+            'g-recaptcha-response' => 'required|captcha',
             'name' => 'required',
             'email' => 'required|email',
             'phone' => 'required',

--- a/app/Http/Controllers/PagesController.php
+++ b/app/Http/Controllers/PagesController.php
@@ -12,7 +12,15 @@ class PagesController extends Controller
         return view('index')->with('event', $currentEvent);
     }
     
-    public function contact(){
+    public function contactGeneral(){
         return view('contact');
+    }
+
+    public function contactTable(){
+        return view('contact-table');
+    }
+
+    public function contactSponsor(){
+        return view('contact-sponsor');
     }
 }

--- a/resources/views/contact-sponsor.blade.php
+++ b/resources/views/contact-sponsor.blade.php
@@ -1,0 +1,64 @@
+@extends('layouts.app')
+
+@section('content')
+
+	@include('layouts.messages')
+
+  	<div class="container conform">	
+
+    	<div class="mt-5 mb-5" style="padding: 20px 40px;">
+			<h1 class="text-white text-center mb-4">Contact Us</h1>
+			<!-- Select Message Type -->
+			
+			<div id="sponsorMessage">
+				<h3 class="text-center">Sponsorship Enquiry</h3>
+				<p class="text-center my-4">Fill this out, and we will contact our potential sponsors closer to the event.</p>
+
+				{{-- Files for download --}}
+				@if(App\Document::where('display_location', 'Sponsor Enquiry')->get()->count() > 0)
+					<div class="mb-3 w-100 text-center">
+						<h5>Related files:</h5>
+						@foreach(App\Document::where('display_location', 'Sponsor Enquiry')->get() as $doc)
+						<a class="d-block" href="{{Storage::disk('documents')->url($doc->filename)}}" download="{{$doc->originalName}}">{{$doc->originalName}}</a>
+						@endforeach
+					</div>
+				@endif
+
+				<small>* Denotes a required field.</small>
+				<form action="{{route('contact.sponsor')}}" method="POST">
+					<div class="row">
+						<div class="form-group col-md-6">
+							<input id="spon_name" name="name" type="text" class="form-control" placeholder="* Your name" required>
+						</div>
+						<div class="form-group col-md-6">
+							<input id="companyName" name="companyName" type="text" class="form-control" placeholder="* Company name" required>
+						</div>
+						<div class="form-group col-md-6">
+							<input id="spon_email" name="email" type="email" class="form-control" placeholder="* Your email address" required>
+						</div>
+					</div>
+					<div class="form-group">
+						<input id="spon_phone" name="phone" type="text" class="form-control" placeholder="* Phone number" required>
+					</div>					
+					<div class="form-group">
+						<label for="spon_type" class="text-white">* What type/s of sponsorship are you interested in?</label>
+						<input id="spon_type" name="type" type="text" class="form-control" required>
+					</div>
+					<div class="form-group">
+						<label for="message" class="text-white">Optional message:</label>
+						<textarea id="spon_message" name="message" class="form-control" rows="5"></textarea>
+					</div>
+					<label for="subscribeCheckbox">
+						<input class="d-inline-block align-middle" type="checkbox" name="subscribeCheckbox" id="subscribeCheckbox" checked>I would like to receive Fight for Kidz updates via email
+					</label>
+					<button type="submit" class="btn btn-primary mt-2 d-block mx-auto">Send Message</button>
+					@csrf
+					{!! app('captcha')->render(); !!}
+				</form>
+			</div>
+			<!-- End Sponsorship contact us form -->
+
+		</div>
+		<!-- End Table contact us form -->			
+	</div>
+@endsection

--- a/resources/views/contact-table.blade.php
+++ b/resources/views/contact-table.blade.php
@@ -1,0 +1,59 @@
+@extends('layouts.app')
+
+@section('content')
+
+	@include('layouts.messages')
+
+  	<div class="container conform">	
+
+    	<div class="mt-5 mb-5" style="padding: 20px 40px;">
+			<h1 class="text-white text-center mb-4">Contact Us</h1>
+			<!-- Select Message Type -->
+
+			<!-- Table contact us form -->
+			<div id="tableMessage">
+				<h3 class="text-center">Enquire about Booking a Table </h3>
+				<p class="text-center my-4">Fill this out, and we will contact you when we can.</p>
+
+				{{-- Files for download --}}
+				@if(App\Document::where('display_location', 'Table Enquiry')->get()->count() > 0)
+					<div class="mb-3 w-100 text-center">
+						<h5>Related files:</h5>
+						@foreach(App\Document::where('display_location', 'Table Enquiry')->get() as $doc)
+						<a class="d-block" href="{{Storage::disk('documents')->url($doc->filename)}}" download="{{$doc->originalName}}">{{$doc->originalName}}</a>
+						@endforeach
+					</div>
+				@endif
+
+				<small>* Denotes a required field.</small>
+				<form action="{{route('contact.table')}}" method="POST">
+					<div class="row">
+						<div class="form-group col-md-6">
+							<input id="tbl_name" name="name" type="text" class="form-control" placeholder="* Your name" required>
+						</div>
+						<div class="form-group col-md-6">
+							<input id="tbl_email" name="email" type="email" class="form-control" placeholder="* Your email address" required>
+						</div>
+					</div>
+					<div class="form-group">
+						<input id="tbl_phone" name="phone" type="text" class="form-control" placeholder="* Phone number" required>
+					</div>					
+					<div class="form-group">
+						<label for="tbl_message" class="text-white">Optional message - What type of table are you looking to book?:</label>
+						<textarea id="tbl_message" name="message" class="form-control" rows="5"></textarea>
+					</div>
+					<label for="subscribeCheckbox">
+						<input class="d-inline-block align-middle" type="checkbox" name="subscribeCheckbox" id="subscribeCheckbox" checked>I would like to receive Fight for Kidz updates via email
+					</label>
+					<button type="submit" class="btn btn-primary mt-2 d-block mx-auto">Send Message</button>
+					@csrf
+					{!! app('captcha')->render(); !!}
+				</form>
+			</div>
+		</div>
+		<!-- End Table contact us form -->		
+
+
+		</div>				
+	</div>
+@endsection

--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -7,24 +7,13 @@
   	<div class="container conform">	
 
     	<div class="mt-5 mb-5" style="padding: 20px 40px;">
-			<h1 class="text-white text-center">Contact Us</h1>
+			<h1 class="text-white text-center mb-4">Contact Us</h1>
 			<!-- Select Message Type -->
-			<div id="messageTypeContainer" class="pb-3">
-				<p class="text-white text-center mt-5">Why do you want to get in touch with us?</p>
-				<select id="messageType" class="form-control" onchange="toggelForm()">
-					<option value="select" {{app('request')->input('option') == null ? 'selected' : null}}>-- Select type of enquiry --</option>
-					<option value="general" {{app('request')->input('option') == 'general' ? 'selected' : null}}>General Enquiry</option>
-					<option value="sponsor" {{app('request')->input('option') == 'sponsor' ? 'selected' : null}}>Become a Sponsor</option>
-					<option value="table" {{app('request')->input('option') == 'table' ? 'selected' : null}}>Table Booking Enquiry</option>
-				</select>
-			</div>
-
-			<hr />
-
+			
 			<!-- Normal contact us form -->
-			<div id="generalMessage" class="hidden">
+			<div id="generalMessage">
 				<h3 class="text-center">General Message</h3>
-				<p class="text-center">Please send us a message and we will get back to you as soon as we can.</p>
+				<p class="text-center my-4">Please send us a message and we will get back to you as soon as we can.</p>
 				<small>* Denotes a required field.</small>
 				<form action="{{route('contact.general')}}" method="POST">
 					<div class="row">
@@ -45,127 +34,14 @@
 					<label for="subscribeCheckbox">
 						<input class="d-inline-block align-middle" type="checkbox" name="subscribeCheckbox" id="subscribeCheckbox" checked>I would like to receive Fight for Kidz updates via email
 					</label>
-					<button class="btn btn-primary mt-2 d-block mx-auto">Send Message</button>
+					<button type="submit" class="btn btn-primary mt-2 d-block mx-auto">Send Message</button>
 					@csrf
 					{!! app('captcha')->render(); !!}
 				</form>
 			</div>
 			<!-- End Normal contact us form -->
-
-			<!-- Sponsorship contact us form -->
-			<div id="sponsorMessage" class="hidden">
-				<h3 class="text-center">Sponsorship Enquiry</h3>
-				<p class="text-center">Fill this out, and we will contact our potential sponsors closer to the event.</p>
-
-				{{-- Files for download --}}
-				@if(App\Document::where('display_location', 'Sponsor Enquiry')->get()->count() > 0)
-					<div class="mb-3 w-100 text-center">
-						<h5>Related files:</h5>
-						@foreach(App\Document::where('display_location', 'Sponsor Enquiry')->get() as $doc)
-						<a class="d-block" href="{{Storage::disk('documents')->url($doc->filename)}}" download="{{$doc->originalName}}">{{$doc->originalName}}</a>
-						@endforeach
-					</div>
-				@endif
-
-				<small>* Denotes a required field.</small>
-				<form action="{{route('contact.sponsor')}}" method="POST">
-					<div class="row">
-						<div class="form-group col-md-6">
-							<input id="spon_name" name="name" type="text" class="form-control" placeholder="* Your name" required>
-						</div>
-						<div class="form-group col-md-6">
-							<input id="companyName" name="companyName" type="text" class="form-control" placeholder="* Company name" required>
-						</div>
-						<div class="form-group col-md-6">
-							<input id="spon_email" name="email" type="email" class="form-control" placeholder="* Your email address" required>
-						</div>
-					</div>
-					<div class="form-group">
-						<input id="spon_phone" name="phone" type="text" class="form-control" placeholder="* Phone number" required>
-					</div>					
-					<div class="form-group">
-						<label for="spon_type" class="text-white">* What type/s of sponsorship are you interested in?</label>
-						<input id="spon_type" name="type" type="text" class="form-control" required>
-					</div>
-					<div class="form-group">
-						<label for="message" class="text-white">Optional message:</label>
-						<textarea id="spon_message" name="message" class="form-control" rows="5"></textarea>
-					</div>
-					<label for="subscribeCheckbox">
-						<input class="d-inline-block align-middle" type="checkbox" name="subscribeCheckbox" id="subscribeCheckbox" checked>I would like to receive Fight for Kidz updates via email
-					</label>
-					<button class="btn btn-primary mt-2 d-block mx-auto">Send Message</button>
-					@csrf
-					{!! app('captcha')->render(); !!}
-				</form>
-			</div>
-			<!-- End Sponsorship contact us form -->
-
-			<!-- Table contact us form -->
-			<div id="tableMessage" class="hidden">
-				<h3 class="text-center">Enquire about Booking a Table </h3>
-				<p class="text-center">Fill this out, and we will contact you when we can.</p>
-
-				{{-- Files for download --}}
-				@if(App\Document::where('display_location', 'Table Enquiry')->get()->count() > 0)
-					<div class="mb-3 w-100 text-center">
-						<h5>Related files:</h5>
-						@foreach(App\Document::where('display_location', 'Table Enquiry')->get() as $doc)
-						<a class="d-block" href="{{Storage::disk('documents')->url($doc->filename)}}" download="{{$doc->originalName}}">{{$doc->originalName}}</a>
-						@endforeach
-					</div>
-				@endif
-
-				<small>* Denotes a required field.</small>
-				<form action="{{route('contact.table')}}" method="POST">
-					<div class="row">
-						<div class="form-group col-md-6">
-							<input id="tbl_name" name="name" type="text" class="form-control" placeholder="* Your name" required>
-						</div>
-						<div class="form-group col-md-6">
-							<input id="tbl_email" name="email" type="email" class="form-control" placeholder="* Your email address" required>
-						</div>
-					</div>
-					<div class="form-group">
-						<input id="tbl_phone" name="phone" type="text" class="form-control" placeholder="* Phone number" required>
-					</div>					
-					<div class="form-group">
-						<label for="tbl_message" class="text-white">Optional message - What type of table are you looking to book?:</label>
-						<textarea id="tbl_message" name="message" class="form-control" rows="5"></textarea>
-					</div>
-					<label for="subscribeCheckbox">
-						<input class="d-inline-block align-middle" type="checkbox" name="subscribeCheckbox" id="subscribeCheckbox" checked>I would like to receive Fight for Kidz updates via email
-					</label>
-					<button class="btn btn-primary mt-2 d-block mx-auto">Send Message</button>
-					@csrf
-					{!! app('captcha')->render(); !!}
-				</form>
-			</div>
+			
 		</div>
 		<!-- End Table contact us form -->			
 	</div>
-	<script>
-		function toggelForm(){
-			let selected = $("#messageType").val();
-
-			$("#generalMessage").addClass("hidden");
-			$("#sponsorMessage").addClass("hidden");
-			$("#tableMessage").addClass("hidden");
-			if(selected == "general") {
-				$("#generalMessage").removeClass("hidden");
-			}
-
-			if(selected == "sponsor") {
-				$("#sponsorMessage").removeClass("hidden");
-			}
-			if(selected == "table") {
-				$("#tableMessage").removeClass("hidden");
-			}
-		}
-
-		$(document).ready(function(){
-			// Set the form to display initially
-			toggelForm();
-		});
-	</script>
 @endsection

--- a/resources/views/layouts/nav.blade.php
+++ b/resources/views/layouts/nav.blade.php
@@ -42,8 +42,16 @@
                 <li class="nav-item"><a href="{{route('merchandise')}}" class="nav-link">Merchandise</a></li>
                 @endif
 
-                <!-- Contact/Subscribe -->
-                <li class="nav-item"><a href="{{route('contact')}}" class="nav-link">Contact Us</a></li>
+                <!-- Contact -->
+                <li class="dropdown"><a data-toggle="dropdown" aria-expanded="false" href="#" class="dropdown-toggle nav-link dropdown-toggle">Contact Us</a>
+                    <div role="menu" class="dropdown-menu">
+                        
+                        <a href="{{route('contact.general')}}" class="dropdown-item">General Enquiry</a>
+                        <a href="{{route('contact.table')}}" class="dropdown-item">Table Booking Enquiry</a>
+                        <a href="{{route('contact.sponsor')}}" class="dropdown-item">Sponsorship Enquiry<a>
+
+                    </div>
+                </li><!-- End Book Tickets -->
             </ul>
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,7 +12,9 @@
 */
 
 Route::get('/', 'PagesController@index')->name('index');
-Route::get('/contact', 'PagesController@contact')->name('contact');
+Route::get('/contact/general', 'PagesController@contactGeneral')->name('contact.general');
+Route::get('/contact/table', 'PagesController@contactTable')->name('contact.table');
+Route::get('/contact/sponsor', 'PagesController@contactSponsor')->name('contact.sponsor');
 Route::get('/event/{eventId}', 'EventController@index')->name('event');
 Route::get('/merchandise', 'MerchandiseController@index')->name('merchandise');
 


### PR DESCRIPTION
Due to the recaptcha library we were using not liking multiple recaptchas on the same page:

- Have split the contact form into three separate pages
- Navbar 'contact us' now a dropdown
- Recaptcha now working on all three forms
- Re-enabled server-side validation of recaptcha results

Have tested on localhost, sending all three form types and viewing the results on the admin panel.