### PR TITLE
Fixed an internal server error that was caused by the router

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -19,6 +19,10 @@ class EventController extends Controller
             $event = Event::where('name', str_replace('-', ' ', $eventName))->first();
         }
 
+        if($event == null) {
+            abort(404, "Event not found");
+        }
+            
         return view('event')->with('event', $event);
     }
 


### PR DESCRIPTION
Fixes an error where a user would cause an internal server error by trying to visit that doesn't exist by providing an invalid event name in the route `HTTP /event/{eventName}`